### PR TITLE
updated field handling of audio start and blocksize

### DIFF
--- a/source/genlib_daisy.h
+++ b/source/genlib_daisy.h
@@ -386,13 +386,8 @@ struct GenDaisy {
 		mode = mode_default;
 
 		hardware.Init(); 
-		#ifdef GEN_DAISY_TARGET_FIELD
-		samplerate = hardware.SampleRate(); // default 48014
-		blocksize = hardware.BlockSize();  // default 48
-		#else
 		samplerate = hardware.AudioSampleRate(); // default 48014
 		blocksize = hardware.AudioBlockSize();  // default 48
-		#endif
 		app_count = count;
 		console.init();
 


### PR DESCRIPTION
This was still being handled in a separate if/else block for the field. That API (for the audio at least) is now the same for all platforms. So this could be removed.